### PR TITLE
Fixing getOne to not error on 0 results

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -220,7 +220,11 @@ class MysqliDb
      public function getOne($tableName, $columns = '*') 
      {
          $res = $this->get ($tableName, 1, $columns);
-         return $res[0];
+         if(isset($res[0])) {
+         	return $res[0];
+		 } else {
+			 return null;
+		 }
      }
 
     /**


### PR DESCRIPTION
Adding a simple isset to check if res[0] is actually set, if so return it if not return null so we don't have a floating result.
