### PR TITLE
Removed bind replacing for _lastQuery

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -620,7 +620,7 @@ class MysqliDb
             call_user_func_array(array($stmt, 'bind_param'), $this->refValues($this->_bindParams));
         }
 
-        $this->_lastQuery = $this->replacePlaceHolders($this->_query, $this->_bindParams);
+        $this->_lastQuery = $this->_query;
         return $stmt;
     }
 
@@ -703,21 +703,6 @@ class MysqliDb
             return $refs;
         }
         return $arr;
-    }
-
-    /**
-     * Function to replace ? with variables from bind variable
-     * @param string $str
-     * @param Array $vals
-     *
-     * @return string
-     */
-    protected function replacePlaceHolders ($str, $vals) {
-        $i = 1;
-        while ($pos = strpos ($str, "?"))
-            $str = substr ($str, 0, $pos) . $vals[$i++] . substr ($str, $pos + 1);
-
-        return $str;
     }
 
     /**


### PR DESCRIPTION
Removed the replacing of ? characters for the _lastQuery debug variable as it broke normal queries containing ? in their strings (undefined offset) even though the queries still executed successfully it printed an error when E_ALL was on. The corresponding function replacePlaceHolders.
